### PR TITLE
removed alternate search logic

### DIFF
--- a/src/commands/music.ts
+++ b/src/commands/music.ts
@@ -4,6 +4,10 @@ import navigate from '../utils/navigate';
 const YOUTUBE_MUSIC_URL = 'https://music.youtube.com/';
 
 export const playMusic = async (args: string[]) => {
+  if (args.length === 0) {
+    return navigate(YOUTUBE_MUSIC_URL);
+  }
+
   const searchQuery = args.join('+');
   const browser = await puppeteer.launch({
     headless: true,
@@ -49,13 +53,6 @@ export const playMusic = async (args: string[]) => {
     }
   );
   let url = `${YOUTUBE_MUSIC_URL}${href}`;
-
-  //This code checks if the URL is a valid URL. If it is, it will open a new browser window at that URL. Otherwise the new browser window will open to the search page.
-  await page.goto(url, { waitUntil: 'networkidle2' });
-
-  if (page.url() !== url) {
-    url = searchUrl;
-  }
 
   await browser.close();
   navigate(url);


### PR DESCRIPTION
The handling of displaying the search URL when an artist or album was searched instead of a specific song was not working when searching specific songs. This reverts back to attempting to navigate to the provided URL, which will take the user to the ytmusic homepage if an artist or album is searched.