### PR TITLE
added refocus logic to music command

### DIFF
--- a/src/commands/music.ts
+++ b/src/commands/music.ts
@@ -1,5 +1,6 @@
 import puppeteer from 'puppeteer';
 import navigate from '../utils/navigate';
+import { refocusWindow } from '../utils/window';
 
 const YOUTUBE_MUSIC_URL = 'https://music.youtube.com/';
 
@@ -55,5 +56,7 @@ export const playMusic = async (args: string[]) => {
   let url = `${YOUTUBE_MUSIC_URL}${href}`;
 
   await browser.close();
+  const refocus = await refocusWindow();
   navigate(url);
+  refocus();
 };


### PR DESCRIPTION
Window focus will now be immediately returned to the command line after opening a browser instance for playing music.